### PR TITLE
✨ Feat: 모르는 단어 생성 및 조회 로직 구현

### DIFF
--- a/src/main/java/com/cojac/storyteller/code/ErrorCode.java
+++ b/src/main/java/com/cojac/storyteller/code/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필을 찾을 수 없습니다."),
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "책을 찾을 수 없습니다."),
     PAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "페이지를 찾을 수 없습니다."),
-
+    UNKNOWN_NOT_FOUND(HttpStatus.NOT_FOUND, "단어를 찾을 수 없습니다"),
 
     /**
      * 405 METHOD_NOT_ALLOWED: 허용되지 않은 Request Method 호출

--- a/src/main/java/com/cojac/storyteller/code/ResponseCode.java
+++ b/src/main/java/com/cojac/storyteller/code/ResponseCode.java
@@ -26,6 +26,11 @@ public enum ResponseCode {
     SUCCESS_UPDATE_IS_FAVORITE(HttpStatus.OK, "즐겨찾기 상태를 성공적으로 변경했습니다."),
 
     /**
+     * UnknownWord
+     */
+    SUCCESS_CREATE_UNKNOWNWORD(HttpStatus.CREATED, "단어가 성공적으로 저장되었습니다"),
+
+    /**
      * Custom status for empty data lists
      */
     SUCCESS_RETRIEVE_EMPTY_LIST(HttpStatus.OK, "데이터 조회를 성공했으나, 목록이 비어 있습니다.");

--- a/src/main/java/com/cojac/storyteller/controller/PageController.java
+++ b/src/main/java/com/cojac/storyteller/controller/PageController.java
@@ -2,13 +2,11 @@ package com.cojac.storyteller.controller;
 
 import com.cojac.storyteller.code.ResponseCode;
 import com.cojac.storyteller.dto.page.PageDetailResponseDTO;
+import com.cojac.storyteller.dto.request.PageRequestDTO;
 import com.cojac.storyteller.dto.response.ResponseDTO;
 import com.cojac.storyteller.service.PageService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/pages")
@@ -17,11 +15,8 @@ public class PageController {
     private final PageService pageService;
 
     @GetMapping("/detail")
-    public ResponseDTO<PageDetailResponseDTO> getPageDetail(
-            @RequestParam Integer profileId,
-            @RequestParam Integer bookId,
-            @RequestParam Integer pageNum ) {
-        PageDetailResponseDTO pageDetail = pageService.getPageDetail(profileId, bookId, pageNum);
+    public ResponseDTO<PageDetailResponseDTO> getPageDetail(@ModelAttribute PageRequestDTO pageRequestDTO) {
+        PageDetailResponseDTO pageDetail = pageService.getPageDetail(pageRequestDTO);
         return new ResponseDTO<>(ResponseCode.SUCCESS_RETRIEVE_PAGE_DETAILS, pageDetail);
     }
 }

--- a/src/main/java/com/cojac/storyteller/controller/UnknownWordController.java
+++ b/src/main/java/com/cojac/storyteller/controller/UnknownWordController.java
@@ -1,0 +1,26 @@
+package com.cojac.storyteller.controller;
+
+import com.cojac.storyteller.code.ResponseCode;
+import com.cojac.storyteller.dto.response.ResponseDTO;
+import com.cojac.storyteller.dto.unknownWord.UnknownWordDetailDto;
+import com.cojac.storyteller.dto.unknownWord.UnknownWordDto;
+import com.cojac.storyteller.service.UnknownWordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/unknownwords")
+@RequiredArgsConstructor
+public class UnknownWordController {
+    private final UnknownWordService unknownWordService;
+    @PostMapping("/create")
+    public ResponseEntity<ResponseDTO<UnknownWordDetailDto>> createUnknownWord(
+            @RequestParam Integer profileId,
+            @RequestParam Integer bookId,
+            @RequestParam Integer pageNum,
+            @RequestBody UnknownWordDto createUnknownWordDto){
+        UnknownWordDetailDto response = unknownWordService.saveUnknownWord(profileId, bookId, pageNum, createUnknownWordDto);
+        return ResponseEntity.ok(new ResponseDTO<>(ResponseCode.SUCCESS_CREATE_UNKNOWNWORD, response));
+    }
+}

--- a/src/main/java/com/cojac/storyteller/controller/UnknownWordController.java
+++ b/src/main/java/com/cojac/storyteller/controller/UnknownWordController.java
@@ -1,6 +1,7 @@
 package com.cojac.storyteller.controller;
 
 import com.cojac.storyteller.code.ResponseCode;
+import com.cojac.storyteller.dto.request.PageRequestDTO;
 import com.cojac.storyteller.dto.response.ResponseDTO;
 import com.cojac.storyteller.dto.unknownWord.UnknownWordDetailDto;
 import com.cojac.storyteller.dto.unknownWord.UnknownWordDto;
@@ -16,11 +17,9 @@ public class UnknownWordController {
     private final UnknownWordService unknownWordService;
     @PostMapping("/create")
     public ResponseEntity<ResponseDTO<UnknownWordDetailDto>> createUnknownWord(
-            @RequestParam Integer profileId,
-            @RequestParam Integer bookId,
-            @RequestParam Integer pageNum,
-            @RequestBody UnknownWordDto createUnknownWordDto){
-        UnknownWordDetailDto response = unknownWordService.saveUnknownWord(profileId, bookId, pageNum, createUnknownWordDto);
+            @ModelAttribute  PageRequestDTO pageRequestDTO,
+            @RequestBody UnknownWordDto unknownWordDto){
+        UnknownWordDetailDto response = unknownWordService.saveUnknownWord(pageRequestDTO, unknownWordDto);
         return ResponseEntity.ok(new ResponseDTO<>(ResponseCode.SUCCESS_CREATE_UNKNOWNWORD, response));
     }
 }

--- a/src/main/java/com/cojac/storyteller/domain/PageEntity.java
+++ b/src/main/java/com/cojac/storyteller/domain/PageEntity.java
@@ -3,6 +3,9 @@ package com.cojac.storyteller.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,6 +30,10 @@ public class PageEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id")
     private BookEntity book;
+
+    @OneToMany(mappedBy = "page", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<UnknownWordEntity> unknownWords = new ArrayList<>();
 
     // BookEntity에서 사용해서 set메서드 하나만 만들었습니다.
     public void setBook(BookEntity book) {

--- a/src/main/java/com/cojac/storyteller/domain/UnknownWordEntity.java
+++ b/src/main/java/com/cojac/storyteller/domain/UnknownWordEntity.java
@@ -21,4 +21,10 @@ public class UnknownWordEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "page_id")
     private PageEntity page;
+
+    public UnknownWordEntity(String unknownWord, Integer position, PageEntity page) {
+        this.unknownWord = unknownWord;
+        this.position = position;
+        this.page = page;
+    }
 }

--- a/src/main/java/com/cojac/storyteller/domain/UnknownWordEntity.java
+++ b/src/main/java/com/cojac/storyteller/domain/UnknownWordEntity.java
@@ -1,0 +1,24 @@
+package com.cojac.storyteller.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class UnknownWordEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false)
+    private String unknownWord;
+
+    @Column(nullable = false)
+    private Integer position;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "page_id")
+    private PageEntity page;
+}

--- a/src/main/java/com/cojac/storyteller/dto/page/PageDetailResponseDTO.java
+++ b/src/main/java/com/cojac/storyteller/dto/page/PageDetailResponseDTO.java
@@ -1,6 +1,9 @@
 package com.cojac.storyteller.dto.page;
 
+import com.cojac.storyteller.dto.unknownWord.UnknownWordDto;
 import lombok.*;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -12,4 +15,6 @@ public class PageDetailResponseDTO {
     private Integer pageNumber;
     private String image;
     private String content;
+    // unknownWord
+    private List<UnknownWordDto> unknownWords;
 }

--- a/src/main/java/com/cojac/storyteller/dto/request/PageRequestDTO.java
+++ b/src/main/java/com/cojac/storyteller/dto/request/PageRequestDTO.java
@@ -1,0 +1,12 @@
+package com.cojac.storyteller.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PageRequestDTO {
+    private Integer profileId;
+    private Integer bookId;
+    private Integer pageNum;
+}

--- a/src/main/java/com/cojac/storyteller/dto/unknownWord/UnknownWordDetailDto.java
+++ b/src/main/java/com/cojac/storyteller/dto/unknownWord/UnknownWordDetailDto.java
@@ -1,0 +1,17 @@
+package com.cojac.storyteller.dto.unknownWord;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnknownWordDetailDto {
+    private Integer bookId;
+    private Integer pageId;
+    private String unknownWord;
+    private Integer position;
+}

--- a/src/main/java/com/cojac/storyteller/dto/unknownWord/UnknownWordDto.java
+++ b/src/main/java/com/cojac/storyteller/dto/unknownWord/UnknownWordDto.java
@@ -1,15 +1,27 @@
 package com.cojac.storyteller.dto.unknownWord;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.cojac.storyteller.domain.UnknownWordEntity;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class UnknownWordDto {
     private String unknownWord;
     private Integer position;
+
+    public static List<UnknownWordDto> toDto(List<UnknownWordEntity> unknownWordEntities) {
+        List<UnknownWordDto> unknownWordDtos = new ArrayList<>();
+        for(UnknownWordEntity unKnownWord : unknownWordEntities) {
+            UnknownWordDto unknownWordDto = new UnknownWordDto(unKnownWord.getUnknownWord(), unKnownWord.getPosition());
+            unknownWordDtos.add(unknownWordDto);
+        }
+        return unknownWordDtos;
+    }
+
 }

--- a/src/main/java/com/cojac/storyteller/dto/unknownWord/UnknownWordDto.java
+++ b/src/main/java/com/cojac/storyteller/dto/unknownWord/UnknownWordDto.java
@@ -1,0 +1,15 @@
+package com.cojac.storyteller.dto.unknownWord;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnknownWordDto {
+    private String unknownWord;
+    private Integer position;
+}

--- a/src/main/java/com/cojac/storyteller/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cojac/storyteller/exception/GlobalExceptionHandler.java
@@ -56,7 +56,7 @@ public class GlobalExceptionHandler {
      * UnknownWord
      */
     @ExceptionHandler(DuplicateUsernameException.class)
-    protected ResponseEntity<ErrorResponseDTO> handleUnknownWordNotFoundException(final UnknownNotFoundException e) {
+    protected ResponseEntity<ErrorResponseDTO> handleUnknownWordNotFoundException(final UnknownWordNotFoundException e) {
         log.error("handleDuplicateUsernameException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getStatus().value())

--- a/src/main/java/com/cojac/storyteller/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cojac/storyteller/exception/GlobalExceptionHandler.java
@@ -52,4 +52,14 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponseDTO(e.getErrorCode()));
     }
 
+    /**
+     * UnknownWord
+     */
+    @ExceptionHandler(DuplicateUsernameException.class)
+    protected ResponseEntity<ErrorResponseDTO> handleUnknownWordNotFoundException(final UnknownNotFoundException e) {
+        log.error("handleDuplicateUsernameException : {}", e.getErrorCode().getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus().value())
+                .body(new ErrorResponseDTO(e.getErrorCode()));
+    }
 }

--- a/src/main/java/com/cojac/storyteller/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cojac/storyteller/exception/GlobalExceptionHandler.java
@@ -55,7 +55,7 @@ public class GlobalExceptionHandler {
     /**
      * UnknownWord
      */
-    @ExceptionHandler(DuplicateUsernameException.class)
+    @ExceptionHandler(UnknownWordNotFoundException.class)
     protected ResponseEntity<ErrorResponseDTO> handleUnknownWordNotFoundException(final UnknownWordNotFoundException e) {
         log.error("handleDuplicateUsernameException : {}", e.getErrorCode().getMessage());
         return ResponseEntity

--- a/src/main/java/com/cojac/storyteller/exception/UnknownNotFoundException.java
+++ b/src/main/java/com/cojac/storyteller/exception/UnknownNotFoundException.java
@@ -1,0 +1,11 @@
+package com.cojac.storyteller.exception;
+
+import com.cojac.storyteller.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UnknownNotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/cojac/storyteller/exception/UnknownWordNotFoundException.java
+++ b/src/main/java/com/cojac/storyteller/exception/UnknownWordNotFoundException.java
@@ -6,6 +6,6 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class UnknownNotFoundException extends RuntimeException {
+public class UnknownWordNotFoundException extends RuntimeException {
     private final ErrorCode errorCode;
 }

--- a/src/main/java/com/cojac/storyteller/repository/UnknownWordRepository.java
+++ b/src/main/java/com/cojac/storyteller/repository/UnknownWordRepository.java
@@ -1,7 +1,12 @@
 package com.cojac.storyteller.repository;
 
+import com.cojac.storyteller.domain.PageEntity;
 import com.cojac.storyteller.domain.UnknownWordEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface UnknownWordRepository extends JpaRepository<UnknownWordEntity, Integer> {
+    Optional<List<UnknownWordEntity>> getByPage(PageEntity page);
 }

--- a/src/main/java/com/cojac/storyteller/repository/UnknownWordRepository.java
+++ b/src/main/java/com/cojac/storyteller/repository/UnknownWordRepository.java
@@ -1,0 +1,7 @@
+package com.cojac.storyteller.repository;
+
+import com.cojac.storyteller.domain.UnknownWordEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UnknownWordRepository extends JpaRepository<UnknownWordEntity, Integer> {
+}

--- a/src/main/java/com/cojac/storyteller/service/PageService.java
+++ b/src/main/java/com/cojac/storyteller/service/PageService.java
@@ -44,14 +44,11 @@ public class PageService {
                 .orElseThrow(() -> new PageNotFoundException(ErrorCode.PAGE_NOT_FOUND));
 
         // 페이지에 해당하는 모르는 단어 가져오기
-        List<UnknownWordEntity> unknownWordEntity = unknownWordRepository.getByPage(page)
+        List<UnknownWordEntity> unknownWordEntities = unknownWordRepository.getByPage(page)
                 .orElseThrow(() -> new UnknownNotFoundException(ErrorCode.UNKNOWN_NOT_FOUND));
 
-        List<UnknownWordDto> unknownWordDtos = new ArrayList<>();
-        for(UnknownWordEntity unKnownWord : unknownWordEntity) {
-            UnknownWordDto unknownWordDto = new UnknownWordDto(unKnownWord.getUnknownWord(), unKnownWord.getPosition());
-            unknownWordDtos.add(unknownWordDto);
-        }
+
+        List<UnknownWordDto> unknownWordDtos = UnknownWordDto.toDto(unknownWordEntities);
 
         return PageDetailResponseDTO.builder()
                 .bookId(book.getId())

--- a/src/main/java/com/cojac/storyteller/service/PageService.java
+++ b/src/main/java/com/cojac/storyteller/service/PageService.java
@@ -10,7 +10,7 @@ import com.cojac.storyteller.dto.unknownWord.UnknownWordDto;
 import com.cojac.storyteller.exception.BookNotFoundException;
 import com.cojac.storyteller.exception.PageNotFoundException;
 import com.cojac.storyteller.exception.ProfileNotFoundException;
-import com.cojac.storyteller.exception.UnknownNotFoundException;
+import com.cojac.storyteller.exception.UnknownWordNotFoundException;
 import com.cojac.storyteller.repository.BookRepository;
 import com.cojac.storyteller.repository.PageRepository;
 import com.cojac.storyteller.repository.ProfileRepository;
@@ -18,7 +18,6 @@ import com.cojac.storyteller.repository.UnknownWordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -45,7 +44,7 @@ public class PageService {
 
         // 페이지에 해당하는 모르는 단어 가져오기
         List<UnknownWordEntity> unknownWordEntities = unknownWordRepository.getByPage(page)
-                .orElseThrow(() -> new UnknownNotFoundException(ErrorCode.UNKNOWN_NOT_FOUND));
+                .orElseThrow(() -> new UnknownWordNotFoundException(ErrorCode.UNKNOWN_NOT_FOUND));
 
 
         List<UnknownWordDto> unknownWordDtos = UnknownWordDto.toDto(unknownWordEntities);

--- a/src/main/java/com/cojac/storyteller/service/PageService.java
+++ b/src/main/java/com/cojac/storyteller/service/PageService.java
@@ -6,6 +6,7 @@ import com.cojac.storyteller.domain.PageEntity;
 import com.cojac.storyteller.domain.ProfileEntity;
 import com.cojac.storyteller.domain.UnknownWordEntity;
 import com.cojac.storyteller.dto.page.PageDetailResponseDTO;
+import com.cojac.storyteller.dto.request.PageRequestDTO;
 import com.cojac.storyteller.dto.unknownWord.UnknownWordDto;
 import com.cojac.storyteller.exception.BookNotFoundException;
 import com.cojac.storyteller.exception.PageNotFoundException;
@@ -29,7 +30,11 @@ public class PageService {
     private final UnknownWordRepository unknownWordRepository;
 
 
-    public PageDetailResponseDTO getPageDetail(Integer profileId, Integer bookId, Integer pageNum) {
+    public PageDetailResponseDTO getPageDetail(PageRequestDTO requestDto) {
+        Integer profileId = requestDto.getProfileId();
+        Integer bookId = requestDto.getBookId();
+        Integer pageNum = requestDto.getPageNum();
+
         // 해당 프로필 가져오기
         ProfileEntity profile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new ProfileNotFoundException(ErrorCode.PROFILE_NOT_FOUND));

--- a/src/main/java/com/cojac/storyteller/service/PageService.java
+++ b/src/main/java/com/cojac/storyteller/service/PageService.java
@@ -4,15 +4,22 @@ import com.cojac.storyteller.code.ErrorCode;
 import com.cojac.storyteller.domain.BookEntity;
 import com.cojac.storyteller.domain.PageEntity;
 import com.cojac.storyteller.domain.ProfileEntity;
+import com.cojac.storyteller.domain.UnknownWordEntity;
 import com.cojac.storyteller.dto.page.PageDetailResponseDTO;
+import com.cojac.storyteller.dto.unknownWord.UnknownWordDto;
 import com.cojac.storyteller.exception.BookNotFoundException;
 import com.cojac.storyteller.exception.PageNotFoundException;
 import com.cojac.storyteller.exception.ProfileNotFoundException;
+import com.cojac.storyteller.exception.UnknownNotFoundException;
 import com.cojac.storyteller.repository.BookRepository;
 import com.cojac.storyteller.repository.PageRepository;
 import com.cojac.storyteller.repository.ProfileRepository;
+import com.cojac.storyteller.repository.UnknownWordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +27,7 @@ public class PageService {
     private final PageRepository pageRepository;
     private final BookRepository bookRepository;
     private final ProfileRepository profileRepository;
+    private final UnknownWordRepository unknownWordRepository;
 
 
     public PageDetailResponseDTO getPageDetail(Integer profileId, Integer bookId, Integer pageNum) {
@@ -35,11 +43,22 @@ public class PageService {
         PageEntity page = pageRepository.findByBookAndPageNumber(book, pageNum)
                 .orElseThrow(() -> new PageNotFoundException(ErrorCode.PAGE_NOT_FOUND));
 
+        // 페이지에 해당하는 모르는 단어 가져오기
+        List<UnknownWordEntity> unknownWordEntity = unknownWordRepository.getByPage(page)
+                .orElseThrow(() -> new UnknownNotFoundException(ErrorCode.UNKNOWN_NOT_FOUND));
+
+        List<UnknownWordDto> unknownWordDtos = new ArrayList<>();
+        for(UnknownWordEntity unKnownWord : unknownWordEntity) {
+            UnknownWordDto unknownWordDto = new UnknownWordDto(unKnownWord.getUnknownWord(), unKnownWord.getPosition());
+            unknownWordDtos.add(unknownWordDto);
+        }
+
         return PageDetailResponseDTO.builder()
                 .bookId(book.getId())
                 .pageNumber(page.getPageNumber())
                 .image(page.getImage())
                 .content(page.getContent())
+                .unknownWords(unknownWordDtos)
                 .build();
     }
 }

--- a/src/main/java/com/cojac/storyteller/service/UnknownWordService.java
+++ b/src/main/java/com/cojac/storyteller/service/UnknownWordService.java
@@ -5,6 +5,7 @@ import com.cojac.storyteller.domain.BookEntity;
 import com.cojac.storyteller.domain.PageEntity;
 import com.cojac.storyteller.domain.ProfileEntity;
 import com.cojac.storyteller.domain.UnknownWordEntity;
+import com.cojac.storyteller.dto.request.PageRequestDTO;
 import com.cojac.storyteller.dto.unknownWord.UnknownWordDetailDto;
 import com.cojac.storyteller.dto.unknownWord.UnknownWordDto;
 import com.cojac.storyteller.exception.BookNotFoundException;
@@ -26,7 +27,10 @@ public class UnknownWordService {
     private final UnknownWordRepository unknownWordRepository;
 
     // 단어 저장
-    public UnknownWordDetailDto saveUnknownWord(Integer profileId, Integer bookId, Integer pageNum, UnknownWordDto unknownWordDto) {
+    public UnknownWordDetailDto saveUnknownWord(PageRequestDTO requestDto, UnknownWordDto unknownWordDto) {
+        Integer profileId = requestDto.getProfileId();
+        Integer bookId = requestDto.getBookId();
+        Integer pageNum = requestDto.getPageNum();
         // 해당 프로필 가져오기
         ProfileEntity profile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new ProfileNotFoundException(ErrorCode.PROFILE_NOT_FOUND));

--- a/src/main/java/com/cojac/storyteller/service/UnknownWordService.java
+++ b/src/main/java/com/cojac/storyteller/service/UnknownWordService.java
@@ -1,0 +1,50 @@
+package com.cojac.storyteller.service;
+
+import com.cojac.storyteller.code.ErrorCode;
+import com.cojac.storyteller.domain.BookEntity;
+import com.cojac.storyteller.domain.PageEntity;
+import com.cojac.storyteller.domain.ProfileEntity;
+import com.cojac.storyteller.domain.UnknownWordEntity;
+import com.cojac.storyteller.dto.unknownWord.UnknownWordDetailDto;
+import com.cojac.storyteller.dto.unknownWord.UnknownWordDto;
+import com.cojac.storyteller.exception.BookNotFoundException;
+import com.cojac.storyteller.exception.PageNotFoundException;
+import com.cojac.storyteller.exception.ProfileNotFoundException;
+import com.cojac.storyteller.repository.BookRepository;
+import com.cojac.storyteller.repository.PageRepository;
+import com.cojac.storyteller.repository.ProfileRepository;
+import com.cojac.storyteller.repository.UnknownWordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UnknownWordService {
+    private final PageRepository pageRepository;
+    private final BookRepository bookRepository;
+    private final ProfileRepository profileRepository;
+    private final UnknownWordRepository unknownWordRepository;
+
+    // 단어 저장
+    public UnknownWordDetailDto saveUnknownWord(Integer profileId, Integer bookId, Integer pageNum, UnknownWordDto unknownWordDto) {
+        // 해당 프로필 가져오기
+        ProfileEntity profile = profileRepository.findById(profileId)
+                .orElseThrow(() -> new ProfileNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
+
+        // 해당 프로필에 해당하는 책 가져오기
+        BookEntity book = bookRepository.findByIdAndProfile(bookId, profile)
+                .orElseThrow(() -> new BookNotFoundException(ErrorCode.BOOK_NOT_FOUND));
+
+        // 해당 책에 해당하는 페이지 가져오기
+        PageEntity page = pageRepository.findByBookAndPageNumber(book, pageNum)
+                .orElseThrow(() -> new PageNotFoundException(ErrorCode.PAGE_NOT_FOUND));
+
+        // UnknownWord 저장
+        UnknownWordEntity unknownWordEntity = new UnknownWordEntity(unknownWordDto.getUnknownWord(), unknownWordDto.getPosition(), page);
+        unknownWordRepository.save(unknownWordEntity);
+
+        UnknownWordDetailDto response = new UnknownWordDetailDto(bookId, pageNum, unknownWordDto.getUnknownWord(), unknownWordDto.getPosition());
+        return response;
+
+    }
+}


### PR DESCRIPTION
<!---- 제목 emoji commitTag: name -->
<!---- ✨ Feat: login -->

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.  -->
- 모르는 단어 생성 로직을 구현했습니다.
- Page를 조회할 때 모르는 단어(unknownwords)도 함께 조회하도록 PageService와 PageDetailResponseDTO를 수정했습니다.

### 이슈 넘버
#16

## PR 유형
어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [x]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [x]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 의논할 부분
- Page에 해당하는 UnknownWord를 조회할 때(getByPage) 예외 처리를 해야 하는데 이때 UnknownNotFoundException를 설정하는 게 맞는지 모르겠습니다! 이미 페이지가 없을 때 바로 위 코드에서 예외 처리를 했었기 때문에 PageNotFoundException을 적용할 필요는 없는데, page로 UnknownWord를 조회하는 것이라 이때 예외 처리를 무엇으로 정하는 게 나을까요?

## 주의 사항
git pull origin main 후 DB를 재생성해야 합니다!