### PR TITLE
:bug: Fix: 색 설정 변경 시 fontSize와 readingSpeed 중 하나의 값만 전달해도 수정 가능하도록 변경

### DIFF
--- a/src/main/java/com/cojac/storyteller/domain/SettingEntity.java
+++ b/src/main/java/com/cojac/storyteller/domain/SettingEntity.java
@@ -35,7 +35,7 @@ public class SettingEntity {
     }
 
     public void updateSetting(SettingDTO settingDTO) {
-        this.fontSize = settingDTO.getFontSize();
-        this.readingSpeed = settingDTO.getReadingSpeed();
+        this.fontSize = settingDTO.getFontSize() == null ? this.fontSize : settingDTO.getFontSize();
+        this.readingSpeed = settingDTO.getReadingSpeed() == null ? this.readingSpeed : settingDTO.getReadingSpeed();
     }
 }

--- a/src/main/java/com/cojac/storyteller/service/SettingService.java
+++ b/src/main/java/com/cojac/storyteller/service/SettingService.java
@@ -38,7 +38,7 @@ public class SettingService {
         // 설정 정보 업데이트
         settingEntity.updateSetting(settingDTO);
 
-        return settingDTO;
+        return SettingDTO.toDto(settingEntity);
     }
 
     public SettingDTO getDetailSettings(Integer profileId, Integer bookId) {


### PR DESCRIPTION
<!---- 제목 emoji commitTag: name -->

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.  -->
* 기존 fontSize와 readingSpeed 중 하나의 값만 전달하면 전달하지 않은 값이 null이 됩니다.
* 프론트 측에서 하나의 값만 수정해도 반영될 수 있었으면 좋겠다고 말씀해주셔서, 만약 하나의 값만 넘겼을 경우 넘기지 않은 다른 값은 null이 아닌 기존 값을 유지하도록 수정했습니다.
* 설정에 성공했다면 요청으로 들어온 DTO 값을 그대로 반환하게 했습니다. 그랬더니 응답에 성공했지만 아래와 같이 값을 넘기지 않을 경우 null로 떠서 설정 조회에 사용했던 방법 그대로 현재 설정 값을 반환하도록 수정했습니다.
``` json
{
    "status": 200,
    "code": "SUCCESS_UPDATE_SETTING",
    "message": "책 설정을 성공적으로 변경했습니다",
    "data": {
        "fontSize": null,
        "readingSpeed": "FAST"
    }
}
``` 

### 이슈 넘버
#44 

## PR 유형
어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [x]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 의논할 부분

## 주의 사항
