### PR TITLE
✨ Feat: process kakao user

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	// AWS
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	// SWAGGER
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/cojac/storyteller/code/ResponseCode.java
+++ b/src/main/java/com/cojac/storyteller/code/ResponseCode.java
@@ -12,6 +12,7 @@ public enum ResponseCode {
      */
     SUCCESS_REGISTER(HttpStatus.OK, "회원가입을 성공했습니다."),
     SUCCESS_LOGIN(HttpStatus.OK, "로그인을 성공했습니다."),
+    SUCCESS_KAKAO_LOGIN(HttpStatus.OK, "카카오 소셜 로그인을 성공했습니다."),
     SUCCESS_REISSUE(HttpStatus.OK, "토큰 재발급을 성공했습니다."),
     SUCCESS_TEST(HttpStatus.OK, "테스트를 성공했습니다."),
     SUCCESS_LOGOUT(HttpStatus.OK, "로그아웃을 성공했습니다."),

--- a/src/main/java/com/cojac/storyteller/config/SecurityConfig.java
+++ b/src/main/java/com/cojac/storyteller/config/SecurityConfig.java
@@ -89,6 +89,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/login", "/", "/register").permitAll()
                         .requestMatchers("/username/verifications", "/emails/verification-requests", "/emails/verifications").permitAll()
+                        .requestMatchers("/kakao-login", "/google-login").permitAll()
                         .requestMatchers("/reissue").permitAll()
                         .anyRequest().authenticated());
 

--- a/src/main/java/com/cojac/storyteller/controller/UserController.java
+++ b/src/main/java/com/cojac/storyteller/controller/UserController.java
@@ -31,10 +31,11 @@ public class UserController {
      * 카카오 소셜 로그인
      */
     @PostMapping("/kakao-login")
-    public ResponseEntity<ResponseDTO> kakaoLogin() {
+    public ResponseEntity<ResponseDTO> kakaoLogin(@RequestBody @Valid KakaoLoginRequestDTO kakaoLoginRequestDTO, HttpServletResponse response) {
+        SocialUserDTO res = userService.kakaoLogin(kakaoLoginRequestDTO, response);
         return ResponseEntity
                 .status(ResponseCode.SUCCESS_REGISTER.getStatus().value())
-                .body(new ResponseDTO<>(ResponseCode.SUCCESS_REGISTER, null));
+                .body(new ResponseDTO<>(ResponseCode.SUCCESS_REGISTER, res));
     }
 
     /**

--- a/src/main/java/com/cojac/storyteller/controller/UserController.java
+++ b/src/main/java/com/cojac/storyteller/controller/UserController.java
@@ -34,8 +34,8 @@ public class UserController {
     public ResponseEntity<ResponseDTO> kakaoLogin(@RequestBody @Valid KakaoLoginRequestDTO kakaoLoginRequestDTO, HttpServletResponse response) {
         SocialUserDTO res = userService.kakaoLogin(kakaoLoginRequestDTO, response);
         return ResponseEntity
-                .status(ResponseCode.SUCCESS_REGISTER.getStatus().value())
-                .body(new ResponseDTO<>(ResponseCode.SUCCESS_REGISTER, res));
+                .status(ResponseCode.SUCCESS_KAKAO_LOGIN.getStatus().value())
+                .body(new ResponseDTO<>(ResponseCode.SUCCESS_KAKAO_LOGIN, res));
     }
 
     /**

--- a/src/main/java/com/cojac/storyteller/controller/UserController.java
+++ b/src/main/java/com/cojac/storyteller/controller/UserController.java
@@ -28,6 +28,16 @@ public class UserController {
     private final UserService userService;
 
     /**
+     * 카카오 소셜 로그인
+     */
+    @PostMapping("/kakao-login")
+    public ResponseEntity<ResponseDTO> kakaoLogin() {
+        return ResponseEntity
+                .status(ResponseCode.SUCCESS_REGISTER.getStatus().value())
+                .body(new ResponseDTO<>(ResponseCode.SUCCESS_REGISTER, null));
+    }
+
+    /**
      * 자체 회원가입
      */
     @PostMapping("/register")

--- a/src/main/java/com/cojac/storyteller/domain/SocialUserEntity.java
+++ b/src/main/java/com/cojac/storyteller/domain/SocialUserEntity.java
@@ -11,15 +11,14 @@ import lombok.NoArgsConstructor;
 @DiscriminatorValue("S")
 public class SocialUserEntity extends UserEntity {
 
-    private String id;
+    private Integer id;
     private String accountId; // 사용자를 식별하는 아이디 (소셜명 + 특정 아이디값)
     private String username; // 사용자 이름
     private String email;
     private String role;
 
     @Builder
-    public SocialUserEntity(String id, String accountId, String username, String email, String role) {
-        this.id = id;
+    public SocialUserEntity(String accountId, String username, String email, String role) {
         this.accountId = accountId;
         this.username = username;
         this.email = email;

--- a/src/main/java/com/cojac/storyteller/domain/SocialUserEntity.java
+++ b/src/main/java/com/cojac/storyteller/domain/SocialUserEntity.java
@@ -1,6 +1,7 @@
 package com.cojac.storyteller.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,9 +11,26 @@ import lombok.NoArgsConstructor;
 @DiscriminatorValue("S")
 public class SocialUserEntity extends UserEntity {
 
-    private Integer id;
+    private String id;
     private String accountId; // 사용자를 식별하는 아이디 (소셜명 + 특정 아이디값)
     private String username; // 사용자 이름
     private String email;
     private String role;
+
+    @Builder
+    public SocialUserEntity(String id, String accountId, String username, String email, String role) {
+        this.id = id;
+        this.accountId = accountId;
+        this.username = username;
+        this.email = email;
+        this.role = role;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updateUsername(String username) {
+        this.username = username;
+    }
 }

--- a/src/main/java/com/cojac/storyteller/domain/SocialUserEntity.java
+++ b/src/main/java/com/cojac/storyteller/domain/SocialUserEntity.java
@@ -13,14 +13,14 @@ public class SocialUserEntity extends UserEntity {
 
     private Integer id;
     private String accountId; // 사용자를 식별하는 아이디 (소셜명 + 특정 아이디값)
-    private String username; // 사용자 이름
+    private String nickname; // 사용자 이름
     private String email;
     private String role;
 
     @Builder
-    public SocialUserEntity(String accountId, String username, String email, String role) {
+    public SocialUserEntity(String accountId, String nickname, String email, String role) {
         this.accountId = accountId;
-        this.username = username;
+        this.nickname = nickname;
         this.email = email;
         this.role = role;
     }
@@ -29,7 +29,7 @@ public class SocialUserEntity extends UserEntity {
         this.email = email;
     }
 
-    public void updateUsername(String username) {
-        this.username = username;
+    public void updateUsername(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/cojac/storyteller/dto/user/KakaoLoginRequestDTO.java
+++ b/src/main/java/com/cojac/storyteller/dto/user/KakaoLoginRequestDTO.java
@@ -13,8 +13,8 @@ public class KakaoLoginRequestDTO {
     private String id;
     @NotBlank(message = "role를 입력해주세요.")
     private String role;
-    @NotBlank(message = "username를 입력해주세요.")
-    private String username;
+    @NotBlank(message = "nickname을 입력해주세요.")
+    private String nickname;
     @NotBlank(message = "email를 입력해주세요.")
     private String email;
 

--- a/src/main/java/com/cojac/storyteller/dto/user/KakaoLoginRequestDTO.java
+++ b/src/main/java/com/cojac/storyteller/dto/user/KakaoLoginRequestDTO.java
@@ -1,0 +1,21 @@
+package com.cojac.storyteller.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoLoginRequestDTO {
+
+    @NotNull(message = "id를 입력해주세요.")
+    private String id;
+    @NotBlank(message = "role를 입력해주세요.")
+    private String role;
+    @NotBlank(message = "username를 입력해주세요.")
+    private String username;
+    @NotBlank(message = "email를 입력해주세요.")
+    private String email;
+
+}

--- a/src/main/java/com/cojac/storyteller/dto/user/SocialUserDTO.java
+++ b/src/main/java/com/cojac/storyteller/dto/user/SocialUserDTO.java
@@ -1,33 +1,28 @@
 package com.cojac.storyteller.dto.user;
 
 import com.cojac.storyteller.domain.SocialUserEntity;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class SocialUserDTO implements UserDTO {
 
-    private String id;
+    private Integer id;
     private String role;
-    private String username; // 실제 유저 이름
+    private String username;
     private String accountId;
-    private String email; // 리소스 서버에서 받은 정보로 사용자의 특정 아이디값
+    private String email;
 
-    @Builder
-    public SocialUserDTO(String accountId, String username, String role, String email) {
-        this.role = role;
-        this.username = username;
-        this.accountId = accountId;
-        this.email = email;
-    }
-
-    public static SocialUserDTO mapToUserDTO(SocialUserEntity socialUser) {
+    public static SocialUserDTO mapToSocialUserDTO(SocialUserEntity socialUser) {
         return SocialUserDTO.builder()
-                .accountId(socialUser.getAccountId())
+                .id(socialUser.getId())
                 .role(socialUser.getRole())
+                .accountId(socialUser.getAccountId())
                 .username(socialUser.getUsername())
                 .email(socialUser.getEmail())
                 .build();

--- a/src/main/java/com/cojac/storyteller/dto/user/SocialUserDTO.java
+++ b/src/main/java/com/cojac/storyteller/dto/user/SocialUserDTO.java
@@ -14,7 +14,7 @@ public class SocialUserDTO implements UserDTO {
 
     private Integer id;
     private String role;
-    private String username;
+    private String nickname;
     private String accountId;
     private String email;
 
@@ -23,7 +23,7 @@ public class SocialUserDTO implements UserDTO {
                 .id(socialUser.getId())
                 .role(socialUser.getRole())
                 .accountId(socialUser.getAccountId())
-                .username(socialUser.getUsername())
+                .nickname(socialUser.getNickname())
                 .email(socialUser.getEmail())
                 .build();
     }

--- a/src/main/java/com/cojac/storyteller/dto/user/SocialUserDTO.java
+++ b/src/main/java/com/cojac/storyteller/dto/user/SocialUserDTO.java
@@ -1,31 +1,35 @@
 package com.cojac.storyteller.dto.user;
 
-import com.cojac.storyteller.dto.user.UserDTO;
-import lombok.AllArgsConstructor;
+import com.cojac.storyteller.domain.SocialUserEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
 public class SocialUserDTO implements UserDTO {
 
-    private Integer id;
+    private String id;
     private String role;
     private String username; // 실제 유저 이름
-    private String accountId; // 리소스 서버에서 받은 정보로 사용자의 특정 아이디값
+    private String accountId;
+    private String email; // 리소스 서버에서 받은 정보로 사용자의 특정 아이디값
 
     @Builder
-    public SocialUserDTO(Integer id, String accountId, String username, String role) {
-        this.id = id;
+    public SocialUserDTO(String accountId, String username, String role, String email) {
         this.role = role;
         this.username = username;
         this.accountId = accountId;
+        this.email = email;
     }
 
-    public SocialUserDTO(String accountId, String username, String role) {
-        this.role = role;
-        this.username = username;
-        this.accountId = accountId;
+    public static SocialUserDTO mapToUserDTO(SocialUserEntity socialUser) {
+        return SocialUserDTO.builder()
+                .accountId(socialUser.getAccountId())
+                .role(socialUser.getRole())
+                .username(socialUser.getUsername())
+                .email(socialUser.getEmail())
+                .build();
     }
 }

--- a/src/main/java/com/cojac/storyteller/service/UserService.java
+++ b/src/main/java/com/cojac/storyteller/service/UserService.java
@@ -68,8 +68,7 @@ public class UserService {
         response.setHeader("access", accessToken);
         response.setHeader("refresh", refreshToken);
 
-        SocialUserDTO socialUserDTO = SocialUserDTO.mapToSocialUserDTO(socialUserEntity);
-        return socialUserDTO;
+        return SocialUserDTO.mapToSocialUserDTO(socialUserEntity);
     }
 
     private SocialUserEntity findOrCreateSocialUser(String accountId, String username, String email, String role) {

--- a/src/main/java/com/cojac/storyteller/service/UserService.java
+++ b/src/main/java/com/cojac/storyteller/service/UserService.java
@@ -57,8 +57,8 @@ public class UserService {
         socialUserRepository.save(socialUserEntity);
 
         //토큰 생성
-        String accessToken = jwtUtil.createJwt("social", "access", username, role, ACCESS_TOKEN_EXPIRATION);
-        String refreshToken = jwtUtil.createJwt("social", "refresh", username, role, REFRESH_TOKEN_EXPIRATION);
+        String accessToken = jwtUtil.createJwt("social", "access", accountId, role, ACCESS_TOKEN_EXPIRATION);
+        String refreshToken = jwtUtil.createJwt("social", "refresh", accountId, role, REFRESH_TOKEN_EXPIRATION);
 
         // Redis에 refresh 토큰 저장
         String refreshTokenKey = REFRESH_TOKEN_PREFIX + username;
@@ -126,7 +126,7 @@ public class UserService {
     /**
      * 토큰 재발급
      */
-    public UserDTO reissueToken(HttpServletRequest request, HttpServletResponse response, @RequestBody ReissueDTO reissueDTO) throws IOException {
+    public UserDTO reissueToken(HttpServletRequest request, HttpServletResponse response, ReissueDTO reissueDTO) throws IOException {
         String refreshToken = getRefreshTokenFromRequest(request);
         validateToken(refreshToken);
         validateCategory(refreshToken);
@@ -248,15 +248,7 @@ public class UserService {
         SocialUserEntity socialUserEntity = socialUserRepository.findByAccountId(accountId)
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
-        UserDTO userDTO = SocialUserDTO.builder()
-                .id(socialUserEntity.getId())
-                .username(socialUserEntity.getUsername())
-                .email(socialUserEntity.getEmail())
-                .accountId(accountId)
-                .role(role)
-                .build();
-
-        return userDTO;
+        return SocialUserDTO.mapToSocialUserDTO(socialUserEntity);
     }
 
     private String hasValueInRedis(String userKey) {

--- a/src/main/java/com/cojac/storyteller/service/UserService.java
+++ b/src/main/java/com/cojac/storyteller/service/UserService.java
@@ -57,8 +57,8 @@ public class UserService {
         socialUserRepository.save(socialUserEntity);
 
         //토큰 생성
-        String accessToken = jwtUtil.createJwt("local", "access", username, role, ACCESS_TOKEN_EXPIRATION);
-        String refreshToken = jwtUtil.createJwt("local", "refresh", username, role, REFRESH_TOKEN_EXPIRATION);
+        String accessToken = jwtUtil.createJwt("social", "access", username, role, ACCESS_TOKEN_EXPIRATION);
+        String refreshToken = jwtUtil.createJwt("social", "refresh", username, role, REFRESH_TOKEN_EXPIRATION);
 
         // Redis에 refresh 토큰 저장
         String refreshTokenKey = REFRESH_TOKEN_PREFIX + username;

--- a/src/main/java/com/cojac/storyteller/service/UserService.java
+++ b/src/main/java/com/cojac/storyteller/service/UserService.java
@@ -48,13 +48,12 @@ public class UserService {
     @Transactional
     public SocialUserDTO kakaoLogin(KakaoLoginRequestDTO kakaoLoginRequestDTO, HttpServletResponse response) {
 
-        String id = kakaoLoginRequestDTO.getId();
-        String accountId = "kakao " + id;
+        String accountId = "kakao " + kakaoLoginRequestDTO.getId();
         String username = kakaoLoginRequestDTO.getUsername();
         String email = kakaoLoginRequestDTO.getEmail();
         String role = kakaoLoginRequestDTO.getRole();
 
-        SocialUserEntity socialUserEntity = findOrCreateSocialUser(id, accountId, username, email, role);
+        SocialUserEntity socialUserEntity = findOrCreateSocialUser(accountId, username, email, role);
         socialUserRepository.save(socialUserEntity);
 
         //토큰 생성
@@ -69,17 +68,18 @@ public class UserService {
         response.setHeader("access", accessToken);
         response.setHeader("refresh", refreshToken);
 
-        return SocialUserDTO.mapToUserDTO(socialUserEntity);
+        SocialUserDTO socialUserDTO = SocialUserDTO.mapToSocialUserDTO(socialUserEntity);
+        return socialUserDTO;
     }
 
-    private SocialUserEntity findOrCreateSocialUser(String id, String accountId, String username, String email, String role) {
+    private SocialUserEntity findOrCreateSocialUser(String accountId, String username, String email, String role) {
         return socialUserRepository.findByAccountId(accountId)
                 .map(existingUser -> {
                     existingUser.updateUsername(username);
                     existingUser.updateEmail(email);
                     return existingUser;
                 })
-                .orElseGet(() -> new SocialUserEntity(id, accountId, username, email, role));
+                .orElseGet(() -> new SocialUserEntity(accountId, username, email, role));
     }
 
     /**
@@ -250,7 +250,8 @@ public class UserService {
 
         UserDTO userDTO = SocialUserDTO.builder()
                 .id(socialUserEntity.getId())
-                .username(socialUserEntity.getEmail())
+                .username(socialUserEntity.getUsername())
+                .email(socialUserEntity.getEmail())
                 .accountId(accountId)
                 .role(role)
                 .build();


### PR DESCRIPTION
## 개요
- 카카오 소셜 로그인한 사용자 정보 처리 로직 추가
- 자체 로그인과 동일한 방식으로` JWT`는 헤더로 전달
- `Refresh 토큰`으로 재발급 로직 정상 작동하는지 확인 완료

++ 
소셜로그인에서 자체 로그인에서 사용하는 `username`을 사용하면 혼동이 올 수도 있을 것 같아 
-> 모두 `nickname`으로 변경했습니다.

### 이슈 넘버
#58 

## PR 유형
어떤 변경 사항이 있나요?

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [X]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 의논할 부분
없습니다~

## 주의 사항
Refreah 토큰으로 재발급을 받을 시
`자체 로그인: username`으로
`소셜 로그인: accountId` 로 보내야 합니다.
자세한 내용은 API 문서에 적어뒀습니다!
