### PR TITLE
✨Feature:  optimize book list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	implementation 'com.google.api-client:google-api-client:1.34.1'
 	implementation 'com.google.http-client:google-http-client-jackson2:1.39.2'
 
+	// cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/cojac/storyteller/config/CacheConfig.java
+++ b/src/main/java/com/cojac/storyteller/config/CacheConfig.java
@@ -1,0 +1,25 @@
+package com.cojac.storyteller.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(cacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/com/cojac/storyteller/dto/book/BookListResponseDTO.java
+++ b/src/main/java/com/cojac/storyteller/dto/book/BookListResponseDTO.java
@@ -3,9 +3,14 @@ package com.cojac.storyteller.dto.book;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.io.Serializable;
+
 @Getter
 @Builder
-public class BookListResponseDTO {
+public class BookListResponseDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     private Integer bookId;
     private String title;
     private String coverImage;

--- a/src/main/java/com/cojac/storyteller/repository/BookRepository.java
+++ b/src/main/java/com/cojac/storyteller/repository/BookRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/cojac/storyteller/service/BookService.java
+++ b/src/main/java/com/cojac/storyteller/service/BookService.java
@@ -81,7 +81,9 @@ public class BookService {
         return BookMapper.mapToBookListResponseDTOs(booksPage.getContent());
     }
 
-    // 즐겨찾기 책 필터링 기능 추가
+    /**
+     * 즐겨찾기 책 목록 조회
+     */
     public List<BookListResponseDTO> getFavoriteBooks(Integer profileId, Pageable pageable) {
         ProfileEntity profile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new ProfileNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
@@ -90,7 +92,9 @@ public class BookService {
         return BookMapper.mapToBookListResponseDTOs(books.getContent());
     }
 
-    // 읽고 있는 책 필터링 기능 추가
+    /**
+     * 읽고 있는 책 목록 조회
+     */
     public List<BookListResponseDTO> getReadingBooks(Integer profileId, Pageable pageable) {
         ProfileEntity profile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new ProfileNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
@@ -99,6 +103,9 @@ public class BookService {
         return BookMapper.mapToBookListResponseDTOs(books.getContent());
     }
 
+    /**
+     * 책 세부 조회
+     */
     public BookDetailResponseDTO getBookDetail(Integer profileId, Integer bookId) {
         ProfileEntity profile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new ProfileNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
@@ -126,7 +133,9 @@ public class BookService {
                 .build();
     }
 
-    // 즐겨찾기 토글 기능 추가
+    /**
+     * 즐겨찾기 토글 기능 추가
+     */
     public Boolean toggleFavorite(Integer profileId, Integer bookId) {
         ProfileEntity profile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new ProfileNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
@@ -141,7 +150,10 @@ public class BookService {
         return newFavoriteStatus;
     }
 
-    // 책 삭제 기능 추가
+    /**
+     * 책 삭제 기능 추가
+     */
+
     @Transactional
     public void deleteBook(Integer profileId, Integer bookId) throws ProfileNotFoundException, BookNotFoundException {
         ProfileEntity profile = profileRepository.findById(profileId)
@@ -153,7 +165,9 @@ public class BookService {
         bookRepository.delete(book);
     }
 
-    // 현재 읽고 있는 페이지 업데이트
+    /**
+     * 현재 읽고 있는 페이지 업데이트
+     */
     @Transactional
     public BookDTO updateCurrentPage(Integer profileId, Integer bookId, Integer currentPage) {
         ProfileEntity profile = profileRepository.findById(profileId)
@@ -173,7 +187,9 @@ public class BookService {
         return BookMapper.mapToBookDTO(book);
     }
 
-    // 퀴즈만 생성
+    /**
+     * 퀴즈만 생성
+     */
     public QuizResponseDTO createQuiz(Integer profileId, Integer bookId) {
         String defaultCoverImage = "defaultCover.jpg";
 

--- a/src/main/java/com/cojac/storyteller/service/BookService.java
+++ b/src/main/java/com/cojac/storyteller/service/BookService.java
@@ -34,7 +34,7 @@ public class BookService {
     private final ProfileRepository profileRepository;
     private final OpenAIService openAIService;
     private final ImageGenerationService imageGenerationService;
-
+    
     /**
      * 동화와 퀴즈 생성
      */
@@ -151,9 +151,8 @@ public class BookService {
     }
 
     /**
-     * 책 삭제 기능 추가
+     * 책 삭제 기능
      */
-
     @Transactional
     public void deleteBook(Integer profileId, Integer bookId) throws ProfileNotFoundException, BookNotFoundException {
         ProfileEntity profile = profileRepository.findById(profileId)


### PR DESCRIPTION
## 개요
동화 목록 조회 성능 최적화 진행

1. 동화 목록 조회 API, 즐겨찾기 목록 조회 API, 읽고 있는 중인 목록 조회 API -> _페이징 적용_
2. 요청 처리 시간 및 쿼리 시간을 분석
-> 쿼리보다는 요청 처리 시간에 문제가 있음 깨닫게 됨
-> 매핑할 때 리스트의 수만큼 해야 하므로 ->  요청 처리 시간이 오래 걸림
-> DTO로 직접 쿼리를 불러오는 것보다는
->  _사용자가 많이 요청할 API로 판단해 캐싱을 적용했습니다._ 

### 이슈 넘버
#67 

## PR 유형
어떤 변경 사항이 있나요?

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [X]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 의논할 부분
1. BOOK에 대한 요청처리 시간 + 쿼리 시간을 분석해본 결과 
-> 조회부분 말고도 책 생성, 책 삭제에 대한 문제가 있는 것 같습니다.
-> 책 생성은 은서님이 해주신 부분이니 
-> 동화 삭제부분만  다음 PR에서 수정해서 올리도록 하겠습니다. 
```
uri: '/books/delete', method: 'DELETE', 요청 처리 시간: 147.510200 ms, 쿼리 개수: 26, 쿼리 시간: 39.202000 ms
```

2. JMeter로 부하 테스트를 진행하려고 했으나 
POST 요청 중에 요청 본문(Request Body)과 URL 파라미터를 사용하는 경우가 있는데
-> JMeter에서는 이러한 형식을 사용하지 못하도록 막아놓은 상태입니다. 
(HTTP 표준에 따라서 두 가지 형식을 혼용하지 않기 때문에 막아놓았더라고요)
--
요청 본문에 포함 시키거나 VS Path Variable를 활용해야 할 것 같은데
이러면 프론트도 수정을 해야 해서...
대회가 마무리가 된 상태라 무조건 수정을 부탁드리기에 애매해서 다른 분들의 의견도 여쭤보려고 여기에 적습니다. 

만약에 수정하지 않으면 부하 테스트는 다른 방식으로도 가능한지 알아보도록 하겠습니다. 

## 주의 사항
