### PR TITLE
🐛 !Hotfix: DB 테이블명 대소문자 구분하여 다시 구성

### DIFF
--- a/src/main/java/com/cojac/storyteller/repository/batch/BatchPageInsert.java
+++ b/src/main/java/com/cojac/storyteller/repository/batch/BatchPageInsert.java
@@ -1,4 +1,4 @@
-package com.cojac.storyteller.repository;
+package com.cojac.storyteller.repository.batch;
 
 import com.cojac.storyteller.domain.PageEntity;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class PageBatchRepository {
+public class BatchPageInsert {
 
     private final JdbcTemplate jdbcTemplate;
 

--- a/src/main/java/com/cojac/storyteller/repository/batch/BatchProfileDelete.java
+++ b/src/main/java/com/cojac/storyteller/repository/batch/BatchProfileDelete.java
@@ -20,31 +20,45 @@ public class BatchProfileDelete {
     public void deleteByProfileId(Integer profileId) {
 
         // 책 ID 목록 조회
-        List<Integer> bookIds = jdbcTemplate.queryForList("SELECT id FROM bookEntity WHERE profile_id = ?", Integer.class, profileId);
+        List<Integer> bookIds = jdbcTemplate.queryForList("SELECT id FROM BookEntity WHERE profile_id = ?", Integer.class, profileId);
 
         if (!bookIds.isEmpty()) {
             // 각 책에 대한 설정 ID를 조회
-            List<Integer> settingIds = jdbcTemplate.queryForList("SELECT setting_id FROM bookEntity WHERE id IN (?)", Integer.class, bookIds);
+            List<Integer> settingIds = jdbcTemplate.queryForList("SELECT setting_id FROM BookEntity WHERE id IN (?)", Integer.class, bookIds);
 
-            // 모르는 단어 삭제
-            jdbcTemplate.batchUpdate(
-                    "DELETE FROM unknownWordEntity WHERE page_id IN (SELECT id FROM pageEntity WHERE book_id = ?)",
-                    new BatchPreparedStatementSetter() {
-                        @Override
-                        public void setValues(PreparedStatement ps, int i) throws SQLException {
-                            ps.setInt(1, bookIds.get(i));
-                        }
+            // 각 책의 페이지 ID 목록 조회
+            List<Integer> pageIds = jdbcTemplate.queryForList("SELECT id FROM PageEntity WHERE book_id IN (?)", Integer.class, bookIds);
 
-                        @Override
-                        public int getBatchSize() {
-                            return bookIds.size();
-                        }
-                    }
-            );
+            // 각 페이지에 대한 모르는 단어가 있는지 확인 후 삭제
+            if (!pageIds.isEmpty()) {
+                List<Integer> unknownWordPageIds = jdbcTemplate.queryForList(
+                        "SELECT DISTINCT page_id FROM UnknownWordEntity WHERE page_id IN (?)",
+                        Integer.class,
+                        pageIds
+                );
+
+                // 모르는 단어 삭제 (존재하는 경우에만)
+                if (!unknownWordPageIds.isEmpty()) {
+                    jdbcTemplate.batchUpdate(
+                            "DELETE FROM UnknownWordEntity WHERE page_id IN (?)",
+                            new BatchPreparedStatementSetter() {
+                                @Override
+                                public void setValues(PreparedStatement ps, int i) throws SQLException {
+                                    ps.setInt(1, unknownWordPageIds.get(i));
+                                }
+
+                                @Override
+                                public int getBatchSize() {
+                                    return unknownWordPageIds.size();
+                                }
+                            }
+                    );
+                }
+            }
 
             // 페이지 삭제
             jdbcTemplate.batchUpdate(
-                    "DELETE FROM pageEntity WHERE book_id = ?",
+                    "DELETE FROM PageEntity WHERE book_id = ?",
                     new BatchPreparedStatementSetter() {
                         @Override
                         public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -60,7 +74,7 @@ public class BatchProfileDelete {
 
             // 책 삭제
             jdbcTemplate.batchUpdate(
-                    "DELETE FROM bookEntity WHERE id = ?",
+                    "DELETE FROM BookEntity WHERE id = ?",
                     new BatchPreparedStatementSetter() {
                         @Override
                         public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -76,7 +90,7 @@ public class BatchProfileDelete {
 
             // 설정 삭제
             jdbcTemplate.batchUpdate(
-                    "DELETE FROM settingEntity WHERE id = ?",
+                    "DELETE FROM SettingEntity WHERE id = ?",
                     new BatchPreparedStatementSetter() {
                         @Override
                         public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -92,8 +106,6 @@ public class BatchProfileDelete {
         }
 
         // 프로필 삭제
-        jdbcTemplate.update("DELETE FROM profileEntity WHERE id = ?", profileId);
+        jdbcTemplate.update("DELETE FROM ProfileEntity WHERE id = ?", profileId);
     }
-
 }
-

--- a/src/main/java/com/cojac/storyteller/service/BookService.java
+++ b/src/main/java/com/cojac/storyteller/service/BookService.java
@@ -13,7 +13,7 @@ import com.cojac.storyteller.dto.page.PageDTO;
 import com.cojac.storyteller.exception.BookNotFoundException;
 import com.cojac.storyteller.exception.ProfileNotFoundException;
 import com.cojac.storyteller.repository.BookRepository;
-import com.cojac.storyteller.repository.PageBatchRepository;
+import com.cojac.storyteller.repository.batch.BatchPageInsert;
 import com.cojac.storyteller.repository.ProfileRepository;
 import com.cojac.storyteller.repository.batch.BatchBookDelete;
 import com.cojac.storyteller.service.mapper.BookMapper;
@@ -39,7 +39,7 @@ public class BookService {
     private final ProfileRepository profileRepository;
     private final OpenAIService openAIService;
     private final ImageGenerationService imageGenerationService;
-    private final PageBatchRepository pageBatchRepository;
+    private final BatchPageInsert batchPageInsert;
     private final BatchBookDelete batchBookDelete;
 
     /**
@@ -72,7 +72,7 @@ public class BookService {
 
         // 페이지 생성
         List<PageEntity> pages = createPage(savedBook, content);
-        pageBatchRepository.batchInsertPages(pages);
+        batchPageInsert.batchInsertPages(pages);
 
         return BookMapper.mapToBookDTO(savedBook, pages);
     }


### PR DESCRIPTION
## 개요
배치 처리한 로직들에서 오류가 나고 있음
-> 테이블명의 문제가 있음을 찾음
-> 리눅스 환경에서는  테이블명의 대소문자를 구분
-> 코드에서도 테이블명을 대소문자 구분하게 수정

### 이슈 넘버
#80 

## PR 유형
어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [X]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 의논할 부분

## 주의 사항
