### PR TITLE
fix: 동화 이미지 중복 생성 문제 해결

### DIFF
--- a/src/main/java/com/cojac/storyteller/service/BookService.java
+++ b/src/main/java/com/cojac/storyteller/service/BookService.java
@@ -75,7 +75,6 @@ public class BookService {
 
             // OpenAI 서비스로부터 동화 생성
             String story = openAIService.generateStory(prompt, age);
-            log.info("Generated story: {}", story);
 
             // 제목과 내용을 분리 (Title: 과 Content: 기준)
             String title = story.split("Content:")[0].replace("Title:", "").trim();
@@ -110,9 +109,6 @@ public class BookService {
 
         for (int i = 0; i < contentParts.length; i++) {
             String trimContent = contentParts[i].trim();
-
-            // 페이지 이미지 생성 및 업로드
-             // log.info("Creating page {} with content: {}", i + 1, trimContent);
 
             String imageUrl = imageGenerationService.generateAndUploadPageImage(trimContent);
 

--- a/src/main/java/com/cojac/storyteller/service/BookService.java
+++ b/src/main/java/com/cojac/storyteller/service/BookService.java
@@ -1,5 +1,6 @@
 package com.cojac.storyteller.service;
 
+import ch.qos.logback.classic.Logger;
 import com.cojac.storyteller.code.ErrorCode;
 import com.cojac.storyteller.domain.BookEntity;
 import com.cojac.storyteller.domain.PageEntity;
@@ -18,6 +19,7 @@ import com.cojac.storyteller.repository.ProfileRepository;
 import com.cojac.storyteller.repository.batch.BatchBookDelete;
 import com.cojac.storyteller.service.mapper.BookMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
@@ -27,11 +29,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class BookService {
 
@@ -42,54 +47,83 @@ public class BookService {
     private final PageBatchRepository pageBatchRepository;
     private final BatchBookDelete batchBookDelete;
 
+    // 동화 생성 중인지 확인하는 맵 (프로필 ID를 키로 사용)
+    private final ConcurrentHashMap<Integer, Boolean> creatingBooks = new ConcurrentHashMap<>();
+
     /**
      * 동화 생성
      */
     @Transactional
     public BookDTO createBook(String prompt, Integer profileId) {
-        ProfileEntity profile = profileRepository.findById(profileId)
-                .orElseThrow(() -> new ProfileNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
+        // 동화 생성 중복 확인
+        if (creatingBooks.getOrDefault(profileId, false)) {
+            throw new IllegalStateException("이미 동화가 생성 중입니다. 나중에 다시 시도해주세요.");
+        }
 
-        // birthDate를 이용하여 age를 계산하는 코드를 추가했습니다.
-        LocalDate birthDate = profile.getBirthDate();
-        LocalDate currentDate = LocalDate.now();
-        int age = Period.between(birthDate, currentDate).getYears();
+        // 동화 생성 중 상태로 설정
+        creatingBooks.put(profileId, true);
 
-        String story = openAIService.generateStory(prompt, age);
+        try {
+            // 프로필 확인
+            ProfileEntity profile = profileRepository.findById(profileId)
+                    .orElseThrow(() -> new ProfileNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
 
-        // 제목과 내용을 분리 (Title: 과 Content: 기준)
-        String title = story.split("Content:")[0].replace("Title:", "").trim();
-        String content = story.split("Content:")[1].trim();
+            // 나이를 계산 (birthDate 기준)
+            LocalDate birthDate = profile.getBirthDate();
+            LocalDate currentDate = LocalDate.now();
+            int age = Period.between(birthDate, currentDate).getYears();
 
-        // Setting 초기 설정
-        SettingEntity setting  = SettingEntity.createDefaultSetting();
+            // OpenAI 서비스로부터 동화 생성
+            String story = openAIService.generateStory(prompt, age);
+            log.info("Generated story: {}", story);
 
-        // 책 표지 이미지 생성 및 업로드
-        String coverImageUrl = imageGenerationService.generateAndUploadBookCoverImage(title);
+            // 제목과 내용을 분리 (Title: 과 Content: 기준)
+            String title = story.split("Content:")[0].replace("Title:", "").trim();
+            String content = story.split("Content:")[1].trim();
 
-        BookEntity book = BookMapper.mapToBookEntity(title, coverImageUrl, profile, setting);
-        BookEntity savedBook = bookRepository.save(book);
+            // Setting 초기 설정
+            SettingEntity setting = SettingEntity.createDefaultSetting();
 
-        // 페이지 생성
-        List<PageEntity> pages = createPage(savedBook, content);
-        pageBatchRepository.batchInsertPages(pages);
+            // 책 표지 이미지 생성 및 업로드
+            String coverImageUrl = imageGenerationService.generateAndUploadBookCoverImage(title);
 
-        return BookMapper.mapToBookDTO(savedBook, pages);
+            // 책 엔티티 생성
+            BookEntity book = BookMapper.mapToBookEntity(title, coverImageUrl, profile, setting);
+            BookEntity savedBook = bookRepository.save(book);
+
+            // 페이지 생성
+            List<PageEntity> pages = createPage(savedBook, content);
+            pageBatchRepository.batchInsertPages(pages);
+
+            // 성공적으로 생성된 동화 반환
+            return BookMapper.mapToBookDTO(savedBook, pages);
+
+        } finally {
+            // 동화 생성이 끝나면 상태를 제거하여 다시 요청 가능하게 함
+            creatingBooks.remove(profileId);
+        }
     }
 
     private List<PageEntity> createPage(BookEntity book, String content) {
         String[] contentParts = content.split("\n\n");
-        List<PageEntity> pages = IntStream.range(0, contentParts.length)
-                .mapToObj(i -> {
-                    String trimContent = contentParts[i].trim();
-                    return PageEntity.builder()
-                            .pageNumber(i + 1)
-                            .content(trimContent)
-                            .image(imageGenerationService.generateAndUploadPageImage(trimContent))
-                            .book(book)
-                            .build();
-                })
-                .collect(Collectors.toList());
+        List<PageEntity> pages = new ArrayList<>();
+
+        for (int i = 0; i < contentParts.length; i++) {
+            String trimContent = contentParts[i].trim();
+
+            // 페이지 이미지 생성 및 업로드
+             // log.info("Creating page {} with content: {}", i + 1, trimContent);
+
+            String imageUrl = imageGenerationService.generateAndUploadPageImage(trimContent);
+
+            PageEntity pageEntity = PageEntity.builder()
+                    .pageNumber(i + 1)
+                    .content(trimContent)
+                    .image(imageUrl)
+                    .book(book)
+                    .build();
+            pages.add(pageEntity);
+        }
 
         return pages;
     }


### PR DESCRIPTION
<!---- 제목 emoji commitTag: name -->
<!---- ✨ Feat: login -->

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.  -->
동화 생성 과정에서 동일한 사용자(프로필)가 동화를 생성하려고 할 때, 의도치 않게 동일한 동화가 여러 번 생성되는 문제가 발생함.
이에 **동화가 생성되는 동안 해당 프로필에 대한 다른 요청을 차단하는 것**으로 문제를 해결해보고자함.
ConcurrentHashMap을 사용하여 동화 생성 중인 프로필을 추적하고, 생성 중일 때는 추가 요청을 받지 않도록 함.

### 이슈 넘버

## PR 유형
어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [x]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 의논할 부분
현재 따로 커스텀 오류를 생성하지 않고 IllegalStateException을 발생시키도록 했습니다.